### PR TITLE
chore(security): upgrade Yew 0.21 & mark optional props (fixes #2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1"
-yew = { version = "0.20", features = ["csr"] }
-yew-router = "0.17"
+yew         = { version = "0.21", features = ["csr"] }
+yew-router  = "0.18"
 web-sys = { version = "0.3", features = ["HtmlInputElement", "HtmlSelectElement", "HtmlTextAreaElement"] }
 gloo-console = "0.2"
 gloo-net = "0.2"
 gloo-storage = "0.2"
 serde = "1.0"
 serde_json = "1.0"
+indexmap = { version = "1.9.3", features = ["serde"] }

--- a/src/components/button.rs
+++ b/src/components/button.rs
@@ -4,11 +4,14 @@ use yew::prelude::*;
 pub struct Props {
     pub label: AttrValue,
     pub button_type: AttrValue,
+
+    #[prop_or_default]
     pub onclick: Option<Callback<MouseEvent>>,
 }
 
 #[function_component(Button)]
 pub fn button(props: &Props) -> Html {
+    // ---
     let classes = classes!("btn", format!("btn-{}", props.button_type));
     match props.onclick.clone() {
         Some(callback) => html! {

--- a/src/components/crate_form.rs
+++ b/src/components/crate_form.rs
@@ -13,12 +13,14 @@ use crate::Route;
 
 #[derive(Properties, PartialEq)]
 pub struct Props {
+    #[prop_or_default]
     pub cr8: Option<Crate>,
     pub authors: Vec<Rustacean>,
 }
 
 #[function_component(CrateForm)]
 pub fn crate_form(props: &Props) -> Html {
+    // ---
     let navigator = use_navigator().expect("Navigator not available");
     let current_user_ctx =
         use_context::<CurrentUserContext>().expect("Current user context is missing");

--- a/src/components/rustacean_form.rs
+++ b/src/components/rustacean_form.rs
@@ -11,11 +11,13 @@ use crate::Route;
 
 #[derive(Properties, PartialEq)]
 pub struct Props {
+    #[prop_or_default]
     pub rustacean: Option<Rustacean>,
 }
 
 #[function_component(RustaceanForm)]
 pub fn rustacean_form(props: &Props) -> Html {
+    // ---
     let navigator = use_navigator().expect("Navigator not available");
     let current_user_ctx =
         use_context::<CurrentUserContext>().expect("Current user context is missing");


### PR DESCRIPTION
### Why
* Address **RUSTSEC-2024-0370** (`proc-macro-error` unmaintained) by moving to Yew 0.21.
* Yew 0.21’s derive macro requires explicit optional props.

### What changed
* **components/button.rs** – `#[prop_or_default]` on `onclick`
* **components/crate_form.rs** – `#[prop_or_default]` on `cr8`
* **components/rustacean_form.rs** – `#[prop_or_default]` on `onclick`
* Regenerated **Cargo.lock** after aligning on `indexmap 1.9.3`
* `cargo clippy --all-targets` clean
* `cargo audit` shows only the unmaintained warning (expected for now)

### How to test
```bash
cargo clippy --all-targets -- -D warnings
cargo audit
trunk serve  # UI still renders & forms work

closes #2 