### PR TITLE
feat(dev-docker): hot-reload container + Rust 1.81 toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Rust build output
+target/
+
+# VCS, editor cruft
+.git/
+*.swp
+*.rs.bk
+.DS_Store
+*~

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     - name: 🦀  Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
-        # host triple + wasm so we can build either way
-        targets: wasm32-unknown-unknown
+        toolchain: 1.81 # Rust 1.81 is the current stable and required by trunk’s deps
+        targets: wasm32-unknown-unknown # host triple + wasm so we can build either way
         components: clippy, rustfmt
 
     - name: 💾  Cache cargo registry + target dirs

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 debug/
 target/
 dist/
+README.html
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# ---- build stage (Rust + Trunk) ----
+# Use Rust 1.81 because newer trunk dependencies (litemap, zerofrom) require it
+FROM rust:1.81 AS build
+WORKDIR /app
+
+# System libs needed for trunk → reqwest → openssl-sys
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pkg-config libssl-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add wasm32-unknown-unknown
+
+# Latest trunk now compiles on Rust 1.81; no version pin required
+RUN cargo install trunk wasm-bindgen-cli --locked
+
+# now copy source for the actual build
+COPY . .
+
+RUN trunk build --release
+
+# ---- runtime stage (hot-reload) ----
+# Re-use everything from the build stage: Rust toolchain, Trunk, source tree
+FROM build AS web
+
+# Expose the HTTP port Trunk will serve on
+EXPOSE 80
+
+# Launch Trunk’s dev server (live-reload inside the container)
+CMD ["trunk", "serve", "--address", "0.0.0.0", "--port", "80", "--open=false"]

--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ Built with ⚡ hot‑reload via Trunk, stateless components, and a clean Tailwi
 
 ## Prerequisites
 
-* **Rust 1.78 +** with the `wasm32-unknown-unknown` target
+* **Rust 1.81&nbsp;+** with the `wasm32-unknown-unknown` target  
   `rustup target add wasm32-unknown-unknown`
-* **Trunk** & **wasm‑bindgen CLI** (one‑time install)
+* **Trunk** & **wasm-bindgen CLI** (one-time install)  
   `cargo install trunk wasm-bindgen-cli --locked`
-* *(Optional)* **Docker ≥ 24** & Docker Compose
+* *(Optional)* **Docker ≥ 24** & Docker Compose
+
+> **Why 1.81?**  
+> Recent Trunk releases—and their transitive crates **`litemap`** and **`zerofrom`**—now require `rustc 1.81` or newer.
 
 ---
 
@@ -43,6 +46,42 @@ For both choices above, open <http://localhost:8080>; edits you make in `src/**`
 To shutdown, for **Native** stop with **Ctrl‑C** or for **Docker** stop with `docker compose down -v`.
 
 ---
+
+> **Heads-up:** When the container starts, Docker Compose may print  
+> `Enable Watch →  watch is not yet configured.`  
+> This is Compose’s optional *file-watch* feature. You don’t need it—  
+> Trunk inside the container already hot-reloads on `src/**` changes.  
+> Simply ignore the prompt (don’t type **w**) and keep coding.
+
+<details>
+<summary><strong>See hot-reload in action&nbsp;(30&nbsp;s)</strong></summary>
+
+   1. Open `src/components/login_form.rs`.  
+   2. Find the line that renders the username field:  
+
+```rust
+   <Input label="Username" ... />
+```
+
+   3. Change **`"Username"`** to **`"Enter your username"`** and **save**.
+   4. Watch the Docker/Trunk terminal — a quick re-compile appears.
+   5. Switch back to the browser (still on `/login`) — the placeholder now reads **Enter your username** without a manual refresh.
+
+*Revert the text and save again to watch it snap back.*
+
+</details>
+
+
+<!-- 
+### Need a tiny production image?  
+
+```bash
+docker build --target prod -t cr8s-fe:latest .
+docker run -p 8080:80 cr8s-fe:latest
+````
+
+---
+-->
 
 ## Running frontend + backend together
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:            # hot-reload mounts
+      - ./src:/app/src
+      - ./index.html:/app/index.html
+      - ./style.scss:/app/style.scss
+    command: ["trunk","serve","--address","0.0.0.0","--port","80","--open=false"]
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 5s
+      retries: 5


### PR DESCRIPTION
* Dockerfile • Multi-stage build on rust:1.81 – installs Trunk + wasm-bindgen – dev runtime re-uses build stage and runs `trunk serve` (live reload)
* docker-compose.yml — mounts src/html/scss and forwards 8080→80
* .dockerignore — exclude target/ and editor cruft
* CI → rust-toolchain 1.81 (was 1.78)
* README • Prerequisites bumped to Rust 1.81 • Added note on ignoring Compose “Enable Watch” prompt • Collapsible 30-second hot-reload demo (edit `login_form.rs`) • Commented stub for future tiny prod image
* .gitignore — add autogenerated README.html