### PR TITLE
chore: Bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cr8s-fe"
-version = "0.1.3"
+version = "0.2.2"
 dependencies = [
  "console_error_panic_hook",
  "gloo-console 0.2.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cr8s-fe"
-version = "0.1.3"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bump version to 0.2.2
    
- Update Cargo.toml version to match git tag progression
- Cargo.lock automatically updated to reflect new version
- Aligns with latest CI improvements and performance fixes
