### PR TITLE
Update quickstart to use new `load-schema` command, fix CI `cargo audit` step, and bump version to v0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,16 @@ jobs:
       - name: ⏳ Wait for frontend to be ready
         run: npx wait-on http://localhost:8080 --timeout 60000
 
-      - name: ✅ Run Playwright E2E tests (login only)
+      - name: ✅ Run login Playwright test
         if: github.event.inputs.run_e2e == 'true' || github.event_name != 'workflow_dispatch'
         run: npx playwright test tests/playwright/login.spec.ts
-        
+
+      - name: 🧪 Run rustaceans Playwright test
+        run: npx playwright test tests/playwright/rustaceans.spec.ts
+
+      - name: 🧪 SKIPPED: crates Playwright test (see cr8s-fe#35)
+        run: echo 'crates.spec.ts skipped due to known issue (cr8s-fe#35)'
+
       - name: 📋 Upload test results on failure
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: 🧪 Run rustaceans Playwright test
         run: npx playwright test tests/playwright/rustaceans.spec.ts
 
-      - name: 🧪 "SKIPPED: crates Playwright test (see cr8s-fe#35)"
+      - name: "🧪 SKIPPED: crates Playwright test (see cr8s-fe issue 35)"
         run: echo 'crates.spec.ts skipped due to known issue (cr8s-fe#35)'
 
       - name: 📋 Upload test results on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: 🧪 Run rustaceans Playwright test
         run: npx playwright test tests/playwright/rustaceans.spec.ts
 
-      - name: 🧪 SKIPPED: crates Playwright test (see cr8s-fe#35)
+      - name: 🧪 "SKIPPED: crates Playwright test (see cr8s-fe#35)"
         run: echo 'crates.spec.ts skipped due to known issue (cr8s-fe#35)'
 
       - name: 📋 Upload test results on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.2.3] - 2025-06-05
+
+### Added
+- ✅ Added Playwright E2E test for `rustaceans.spec.ts` to GitHub Actions workflow
+- 📝 Documented manual E2E testing updates in `manual-e2e-tests.md`
+
+### Changed
+- 🚧 Skipped flaky `crates.spec.ts` test (see cr8s-fe#35) in CI workflow with clear log message
+- 🔄 Updated `quickstart.sh` to use new `load-schema` CLI command from cr8s v0.4.7
+- 🛠 Switched to backend image version `v0.4.7` (set `USE_DEV_CONTAINER=true` for local dev builds)
+
+### Fixed
+- Minor doc clarifications and CI consistency fixes for better test reliability
+
 ## [v0.2.2] - 2025-06-03
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cr8s-fe"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "console_error_panic_hook",
  "gloo-console 0.2.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cr8s-fe"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/manual-e2e-tests.md
+++ b/docs/manual-e2e-tests.md
@@ -7,6 +7,7 @@ This document describes how to run Playwright-based end-to-end tests against the
 - **No local Node.js or Rust required**: All tooling runs in containers
 - Docker and Docker Compose v2 must be installed and running
 - Services running via `./scripts/quickstart.sh`
+- Run it with `--help` to get latest usage message. 
 
 ## 🚀 Running E2E Tests
 
@@ -46,8 +47,8 @@ To visually observe test execution in a real browser window:
 To reset the test environment between test runs:
 
 > ```bash
-> ./scripts/shutdown.sh
-> ./scripts/quickstart.sh
+> ./scripts/quickstart.sh ...
+> ./scripts/quickstart.sh --shutdown
 > ```
 
 > ⚠️ This will erase your local database (including seeded data).

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -206,7 +206,7 @@ if [[ "$LINT_MODE" != "none" ]]; then
     # Additional checks only with --full-lint
     if [[ "$LINT_MODE" == "full" ]]; then
         echo "${progname}: 🔒 Running security audit..."
-        ${RUST_DEV_COMMAND} web cargo audit --ignore RUSTSEC-2023-0071 || true
+        ${RUST_DEV_COMMAND} cargo audit --ignore RUSTSEC-2023-0071 || true
         
         echo "${progname}: 📦 Checking for outdated dependencies..."
         ${RUST_DEV_COMMAND} cargo outdated || true


### PR DESCRIPTION
### Summary

This PR updates `cr8s-fe` to align with the new `load-schema` CLI functionality in `cr8s v0.4.7`, improves robustness of the `quickstart.sh` script, and fixes a CI error related to `cargo audit` failing due to a missing container entrypoint.

### Changes

- 🛠 Updated `quickstart.sh` to call `cr8s-cli init-database --load-schema` for schema bootstrapping
- 🔐 Fixed `cargo audit` step to correctly run inside the dev container:
  ```bash
  ${RUST_DEV_COMMAND} cargo audit --ignore RUSTSEC-2023-0071 || true
````

* 🐛 Fixed minor syntax issues in `quickstart.sh` and GitHub workflow YAML
* ✅ Added E2E test for `rustaceans.spec.ts` in CI
* 🚧 Temporarily skipped `crates.spec.ts` E2E in CI (see `cr8s-fe#35`)
* 🔖 Version bump to `v0.2.3`
* 📄 Updated `manual-e2e-tests.md` instructions

### Related

* Requires `cr8s` version `v0.4.7`+
* Partial resolution for `cr8s-fe#35` (skipping test in CI)

