### PR TITLE
docs: update quickstart instructions for Rust CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Built with ⚡ hot‑reload via Trunk, stateful components, and a clean Tailwind
 ## Quick Start  
 
 > ```bash
-> ./scripts/quickstart.sh
+> cargo build -p quickstart
+> target/debug/quickstart start --lint basic
 > ```
 
 This launches the full stack:
- - Starts PostgreSQL, Redis, and cr8s backend (v0.4.6)
+ - Starts PostgreSQL, Redis, and cr8s backend
  - Loads database schema and default roles
  - Creates test user: `admin@example.com` / `password123` (with admin, editor, viewer roles)
  - Launches the frontend with hot reload on http://localhost:8080
@@ -37,14 +38,22 @@ Open <http://localhost:8080>; edits you make in `src/**` will hot‑reload in ~1
 To stop all services and remove containers and volumes:
 
 > ```
-> ./scripts/quickstart.sh --shutdown
+> target/debug/quickstart shutdown
 > ```
 > Note: this also removes database volumes — login data will be reset.
+> for volume mounts, CI integration, and multi-service workflow.
+> 💡 Prefer Docker? See [dev-container-usage.md](docs/dev-container-usage.md)  
 
 ### Development Workflow
 
 **Configuration:**
-- Backend version is controlled by `cli/src/quickstart.sh`, search for CR8S_VERSION in this file to see current version.
+- Backend version is controlled by `cli/src/main.rs`, search for CR8S_VERSION in this file to see current version.
+> ```
+> fn get_cr8s_version() -> String {
+>     // This is the version of cr8s BE that we are targeting.
+>     get_env_with_default("CR8S_VERSION", "0.5.1")
+> }
+```
 - See [dev-container-usage.md](docs/dev-container-usage.md) for up-to-date instructions on using the containerized development environment. This includes lint checks, image builds, volume reuse, and CI integration.
 - Frontend source code mounted for hot reload development
 - Database persists between restarts (until `shutdown.sh` runs)

--- a/tests/playwright/rustaceans.spec.ts
+++ b/tests/playwright/rustaceans.spec.ts
@@ -2,25 +2,37 @@ import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './utils/auth';
 
 test('can add a rustacean', async ({ page }) => {
-  await test.step('Login as admin', async () => {
-    await loginAsAdmin(page);
-  });
+    await test.step('Login as admin', async () => {
+        await loginAsAdmin(page);
+    });
 
-  await test.step('Navigate to Rustaceans list', async () => {
-    await page.click('text=Rustaceans');
-  });
+    await test.step('Navigate to Rustaceans list', async () => {
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'load' }),
+            page.click('text=Rustaceans'),
+        ]);
 
-  await test.step('Add a new rustacean', async () => {
-    const name = 'Playwright Test';
-    const email = `test-${Date.now()}@example.com`;
+        await expect(page).toHaveURL(/.*rustaceans/);
+    });
 
-    await page.click('text=Add new rustacean');
-    await page.fill('input[name="name"]', name);
-    await page.fill('input[name="email"]', email);
-    await page.click('text=Save');
+    await test.step('Add a new rustacean', async () => {
+        try {
+            const name = 'Playwright Test';
+            const email = `test-${Date.now()}@example.com`;
 
-    const row = page.locator('tr', { hasText: email });
-    await expect(row).toContainText(name);
-    await expect(row).toContainText(email);
-  });
+            await page.waitForSelector('text=Add new rustacean', { timeout: 10000 });
+            await page.click('text=Add new rustacean');
+            await page.fill('input[name="name"]', name);
+            await page.fill('input[name="email"]', email);
+            await page.click('text=Save');
+
+            const row = page.locator('tr', { hasText: email });
+            await expect(row).toContainText(name);
+            await expect(row).toContainText(email);
+        } catch (e) {
+            await page.screenshot({ path: 'rustaceans-failure.png', fullPage: true });
+            console.error(await page.content());
+            throw e;
+        }
+    });
 });


### PR DESCRIPTION
- Replaces references to legacy ./scripts/quickstart.sh
- Adds build + run instructions using the `quickstart` Rust binary
- Shows correct shutdown command: `target/debug/quickstart shutdown`
- Clarifies CR8S_VERSION source and embeds example code
- Leaves GitHub-friendly relative link to dev-container-usage.md unchanged