### PR TITLE
docs(changelog): clean up v0.3.0 and add v0.3.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.1] – 2025-06-09
+
+### Added
+
+- 💡 Clarified usage of container vs host `quickstart` binary in `manual-e2e-tests.md`
+- 📝 Documented `CR8S_SCRATCH_DIR` in Docker Compose volumes
+- 🧪 Documented `cargo install` method for CLI usability on host
+- 📄 `Dockerfile.fe-server` now enforces required build args with early failure
+- 🧼 Expanded `quickstart shutdown` doc to explain dev volume cleanup
+
+### Changed
+
+- 📚 Simplified frontend startup instructions in docs; clarified Trunk role and port 8080
+- 🐳 Docker Compose now respects `${CR8S_SCRATCH_DIR:-/var/tmp}` for frontend caching
+- 🧪 Replaced `target/debug/quickstart` with `quickstart` in all doc examples
+- ✅ Reworded CI integration section to match current `quickstart` usage
+
+### Fixed
+
+- 🧪 CI flake in WebKit Playwright test: added `waitForNavigation()` and fallback logging
+
 ## [v0.3.0] – 2025-06-08
 
 ### Added
 
-* 📝 Added new documentation: `Dev-container-usage.md` for containerized development, linting, and volume mounts
-* 🚀 **New Rust-based CLI tool**: `quickstart` binary fully replaces `scripts/quickstart.sh`
-
-  * Supports subcommands: `start`, `shutdown`, and `wait`
-  * Supports flags: `--lint`, `--dry-run`, `--fresh`, `--dev`, and more
-  * Leverages `clap`, `tracing`, and container-based linting with dynamic script generation
-* 🪵 Structured logging via `tracing` with configurable `--log-level`
-* 🧪 Full CI integration with `target/debug/quickstart` used in place of shell script
-* 🧹 Auto-cleanup of `/tmp/dev-*` volumes via `--shutdown`
+- 🚀 **New Rust-based CLI tool**: `quickstart` binary replaces `scripts/quickstart.sh`
+  - Supports: `start`, `shutdown`, `wait` subcommands
+  - Flags: `--lint`, `--dry-run`, `--fresh`, `--dev`, etc.
+  - Uses `clap`, `tracing`, and dynamic shell script generation for linting
+- 📝 `dev-container-usage.md`: containerized dev environment, linting, and volume caching
+- 🪵 Structured logging via `tracing` with configurable log level
+- 🧪 CI pipeline updated to run all lint/tests via `quickstart`
 
 ### Changed
 
-* 🐳 All Docker Compose image variables moved to explicit `FE_SERVER_IMAGE`, `BE_SERVER_IMAGE`, etc., improving environment clarity
-* 📄 `Dockerfile.fe-server` now tagged independently of BE and uses consistent `dev` user
+- 🐳 Docker Compose now uses `FE_SERVER_IMAGE`, `BE_SERVER_IMAGE`, etc. for clarity
+- 📄 `Dockerfile.fe-server` accepts `CR8S_VERSION` and `FE_BASE_IMAGE` with validation
+- 📁 `target/debug/quickstart` is now the default entry for all local and CI workflows
 
 ### Removed
 
-* ❌ Legacy `scripts/quickstart.sh` deleted after confirming parity with Rust implementation
-
----
+- ❌ `scripts/quickstart.sh` removed after confirming full parity with Rust CLI
 
 ## [v0.2.4] - 2025-06-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "cr8s-fe"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "console_error_panic_hook",
  "gloo-console 0.2.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cr8s-fe"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile.fe-server
+++ b/Dockerfile.fe-server
@@ -1,10 +1,23 @@
-# This dockerfile builds a frontend server image with default name 'cr8s-fe-server'
-ARG FE_BASE_IMAGE="junk"
-ARG CR8S_VERSION="junk"
+# Dockerfile.fe-server
+# ---------------------
+# Builds the frontend server image, typically named 'cr8s-fe-server'.
+# This Dockerfile is invoked by `quickstart start` to launch the dev or test stack.
+#
+# Required build arguments (must be overridden by caller):
+# - FE_BASE_IMAGE: base image containing the built frontend app
+# - CR8S_VERSION: version label for diagnostics/logging
+#
+ARG FE_BASE_IMAGE="not set"      # Must be overridden
+ARG CR8S_VERSION="not set"       # Must be overridden
+
 FROM ${FE_BASE_IMAGE}
-# Install curl for health checks
+
+# Install curl (used by health check probes)
 USER root
-RUN echo "Building server version ${CR8S_VERSION}" ; \
-    apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN test "$FE_BASE_IMAGE" != "not set" && \
+    test "$CR8S_VERSION"  != "not set" && \
+    echo "Building server version ${CR8S_VERSION}" && \
+    apt-get update && apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/*
 
 USER dev

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::EnvFilter;
 #[derive(Parser)]
 #[command(name = "quickstart", version, about = "Start or stop cr8s services")]
 struct Cli {
-    /// Override log level (e.g. error, warn, info, debug, trace)
+    /// Override log level
     #[arg(long, value_enum)]
     log_level: Option<LogLevel>,
 
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long)]
     dry_run: bool,
 
-    /// Developer mode (base image from local docker registery)
+    /// Developer mode (uses cr8s-server-dev from local docker registery)
     #[arg(long)]
     dev: bool,
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  # Backend infrastructure
+  # Backend infrastructure (postgres + redis)
   postgres:
     image: postgres:15
     environment:
@@ -26,7 +26,7 @@ services:
 
   # Backend server (cr8s)
   server:
-    image: ${BE_SERVER_IMAGE:-} # Required
+    image: ${BE_SERVER_IMAGE:-} # Required parameter
     working_dir: /app
     entrypoint: []  # Clear the existing entrypoint
     command: [ "sh", "-c", "./server ${SERVER_DEBUG_ARGS:-}" ]
@@ -50,9 +50,9 @@ services:
       timeout: 30s
       retries: 5
 
-  # CLI tool (optional, for admin tasks)
+  # CLI tool (for admin tasks)
   cli:
-    image: ${BE_CLI_IMAGE:-}    # Required
+    image: ${BE_CLI_IMAGE:-}    # Required parameter
     depends_on:
       postgres:
         condition: service_healthy
@@ -62,12 +62,12 @@ services:
       DATABASE_URL: postgres://postgres:secret@postgres:5432/cr8s
       REDIS_URL: redis://redis:6379/
     profiles:
-      - tools  # Only start when explicitly requested with --profile tools
+      - tools  # Only start when explicitly requested with `docker compose run cli ...`
 
   # Frontend (cr8s-fe) with hot reload
   web:
-    user: root
-    image: ${FE_SERVER_IMAGE:-} # Required
+    user: root # We're currently in dev mode so this is Ok, don't do this for production
+    image: ${FE_SERVER_IMAGE:-} # Required parameter
     ports:
       - "8080:80"
     volumes:            # hot-reload mounts
@@ -78,8 +78,8 @@ services:
       - ./index.html:/app/index.html
       - ./style.scss:/app/style.scss
       - ./yew-logo.svg:/app/yew-logo.svg
-      - /var/tmp/dev-cargo:/usr/local/cargo/registry
-      - /var/tmp/dev-target:/app/target
+      - ${CR8S_SCRATCH_DIR:-/var/tmp}/dev-cargo:/usr/local/cargo/registry
+      - ${CR8S_SCRATCH_DIR:-/var/tmp}/dev-target:/app/target
     depends_on:
       server:
         condition: service_healthy

--- a/docs/dev-container-usage.md
+++ b/docs/dev-container-usage.md
@@ -1,0 +1,103 @@
+# Development Environment: Container-Based Workflow
+
+This document describes how the `cr8s-fe` project uses a containerized development environment to provide consistent linting, builds, and local test automation across machines.
+
+---
+
+## Quickstart CLI
+
+The `quickstart` binary orchestrates the entire dev environment. It runs services via Docker Compose, performs lint checks, builds images, and coordinates frontend and backend startup.
+
+```bash
+cargo run --bin quickstart -- start --lint full
+```
+
+👉 Run `quickstart --help` and `quickstart start --help` for the most up-to-date usage instructions.
+
+Flags:
+
+* `--lint [none|basic|full]`: Controls lint checks (e.g., `cargo fmt`, `clippy`, `audit`, `outdated`)
+* `--dev`: _(currently a work-in-progress)_ Intended to use locally built dev images (e.g., `cr8s-server-dev`) instead of pulling from GHCR. This will eventually support testing local backend changes before pushing to the registry.
+* `--dry-run`: Prints commands without executing them
+
+---
+
+## Lint Checks in Container
+
+To avoid host mismatches (e.g., toolchain version, UID), all lint checks are performed inside the dev container.
+
+### Script Generation
+
+`quickstart` generates a `run-checks.sh` file based on the `LintMode`.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+...
+```
+
+This file is mounted into a temporary container and executed using the `cr8s` ecosystem's custom Rust dev image:
+
+```bash
+docker run --rm -u root \
+  -v "$PWD:$PWD" \
+  -v /var/tmp/dev-target:/app/target \
+  -v /var/tmp/dev-cargo:/usr/local/cargo/registry \
+  -w $PWD ghcr.io/johnbasrai/cr8s/rust-dev:1.83.0-rev5 \
+  ./run-checks.sh
+```
+
+**Note:** If `/var/tmp` is not usable on your system or CI runner, override via:
+
+```bash
+# For example
+export CR8S_SCRATCH_DIR="$HOME/tmp"
+```
+CI workflow can use: 
+```
+    CR8S_SCRATCH_DIR: ${{ runner.temp }}/cr8s-scratch
+```
+---
+
+## Scratch Volume Usage
+
+To speed up builds and avoid permission errors:
+
+- `/app/target` → `${CR8S_SCRATCH_DIR:-/tmp/tmp}/dev-target`
+- `/usr/local/cargo/registry` → `${CR8S_SCRATCH_DIR:-/tmp/tmp}/dev-cargo`
+
+These volumes are reused across container runs and cleaned up via:
+
+```bash
+quickstart shutdown
+# which runs:
+docker compose down -v
+sudo rm -rf "$CR8S_SCRATCH_DIR/dev-target" "$CR8S_SCRATCH_DIR/dev-cargo"
+```
+
+✅ As of **v0.3.0**, both `quickstart` and `docker-compose.yml` now default to the same scratch path fallback: `/tmp/tmp`. When `CR8S_SCRATCH_DIR` is set, all tooling — including Compose volume mounts — will respect this value for consistent cross-environment behavior.
+
+
+## Frontend Compilation and Playwright
+
+Frontend is served via `trunk` inside the `web` container.
+
+```yaml
+volumes:
+  - ./src:/app/src
+  - ./index.html:/app/index.html
+```
+
+Manual Playwright tests can be run after startup:
+
+```bash
+npx playwright test tests/playwright/login.spec.ts
+```
+
+---
+
+## Version Tagging
+
+Images built by `quickstart` are tagged with `CR8S_VERSION`, e.g., `cr8s-fe-server:latest`. By default, this version is read from the top-level `Cargo.toml`, or overridden via the `CR8S_VERSION` environment variable.

--- a/docs/manual-e2e-tests.md
+++ b/docs/manual-e2e-tests.md
@@ -13,29 +13,51 @@ This document describes how to run Playwright-based end-to-end tests against the
 
 Ensure services are running first. Choose your preferred startup mode:
 
+💡 **Note:** If you're running `quickstart` via the container-based workflow, the CLI binary is built inside the dev container under:
+
+```bash
+${CR8S_SCRATCH_DIR:-/tmp/tmp}/dev-target/debug/quickstart
+```
+
+This is a temporary path and will be deleted when you run:
+
+```bash
+quickstart shutdown
+```
+
+To avoid this and run `quickstart` consistently from your host:
+
+```bash
+cargo install --path cli --bin quickstart
+```
+
+This installs it to `$CARGO_HOME/bin` (usually `~/.cargo/bin`), so you can run it from anywhere like:
+
 > ```bash
-> # Standard startup with basic lint checks (recommended for testing)
-> target/debug/quickstart start --fresh --lint medium
+> # Recommended for testing
+> quickstart start --fresh --lint basic
 > 
 > # Fast startup for quick test iterations
-> target/debug/quickstart start --fresh --lint none
+> quickstart start --fresh --lint none
 > 
-> # Comprehensive startup with full lint suite
-> target/debug/quickstart start --fresh --lint full
+> # Comprehensive startup with full lint suite (used by CI workflow)
+> quickstart start --fresh --lint full
 > ```
 
-Ater you start the service you the first you should wait the frontend finish initializing
+After you start the service the first time, you should wait for the frontend to finish initializing. This gives **Trunk**, the Rust/WASM bundler, time to compile the frontend code in `cr8s-fe/src` and serve it on port `8080`.
+
+Use the following command:
 >```
-> target/debug/quickstart wait
+> quickstart wait
 >```
 
-Then run Playwright tests across Chromium, Firefox, and WebKit:
-
+Once `quickstart wait` returns, run Playwright tests across Chromium, Firefox, and WebKit:
 > ```bash
 > npx playwright test tests/playwright/login.spec.ts
 > npx playwright test tests/playwright/rustaceans.spec.ts
-> npx playwright test tests/playwright/crates.spec.ts
+> npx playwright test tests/playwright/crates.spec.ts # Currently not working*
 > ```
+* See [Issue #35](https://github.com/JohnBasrai/cr8s/issues/35)
 
 ## 🧪 Running Tests in Headed Mode
 
@@ -52,10 +74,10 @@ To visually observe test execution in a real browser window:
 To reset the test environment between test runs:
 
 > ```bash
-> target/debug/quickstart shutdown
+> quickstart shutdown
 > ```
 
-> ⚠️ This will erase your local database (including seeded data).
+> ⚠️ This will erase your local database (including seeded data) and also deletes scratch volumes under `${CR8S_SCRATCH_DIR}` (e.g., `/var/tmp/dev-target`, `/var/tmp/dev-cargo`).
 
 ## 📧 Test Credentials
 
@@ -68,7 +90,7 @@ To reset the test environment between test runs:
 E2E tests now run by default in the CI pipeline with improved performance:
 
 1. **Fast execution**: Complete CI pipeline runs in under 4 minutes
-2. Runs `quickstart.sh --full-lint` for comprehensive code quality checks
+2. Runs `quickstart start --lint full` for comprehensive code quality checks
 3. Executes Playwright login tests across all browsers
 4. Uploads test artifacts on failure for debugging
 5. **Optimized permissions**: Automatic user permission handling across environments
@@ -85,5 +107,5 @@ To disable E2E tests in CI, use `workflow_dispatch` with `run_e2e=false`.
 - Container rebuilds ensure latest code changes are reflected in tests
 
 ## Bugs
-
-> 📝 Note: See [Issue #10](https://github.com/JohnBasrai/cr8s-fe/issues/10) for details on why `npx playwright test` is currently avoided in favor of running each test file directly.
+> 📝 See [Issue #10](https://github.com/JohnBasrai/cr8s-fe/issues/10) for details on why `npx playwright test` is currently avoided in favor of running each test file directly.
+> 📝 See [Issue #35](https://github.com/JohnBasrai/cr8s/issues/35) for details on why `crates.spec.ts` playwright test is disabled.


### PR DESCRIPTION
- Refined v0.3.0 section for clarity and structure
  - Highlights CLI rewrite, Compose changes, and logging
- Added v0.3.1 section documenting recent improvements:
  - Container vs host quickstart usage
  - CR8S_SCRATCH_DIR volumes and shutdown cleanup
  - Dockerfile arg validation and Playwright flake fix