### PR TITLE
docs: update scratch volume path default to /var/tmp & fix project tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,14 @@ cr8s-fe/
 ├── Cargo.toml
 ├── README.md
 ├── CHANGELOG.md
+├── cli
+│   ├── Cargo.toml
+│   └── src
+│       └── main.rs
 ├── docs/
+│   ├── dev-container-usage.md
 │   └── manual-e2e-tests.md     # E2E instructions for local dev
-├── public/
-│   └── index.html              # App entrypoint
-├── scripts/
-│   └── quickstart.sh           # One-command dev startup (backend + frontend)
+├── index.html                  # App entrypoint
 ├── src/
 │   ├── api/                    # REST/GraphQL helpers
 │   ├── components/             # Reusable Yew components
@@ -149,6 +151,7 @@ cr8s-fe/
 ├── style.scss
 ├── tests/
 │   └── playwright/             # E2E browser tests (Playwright)
+├── Dockerfile.fe-server        # Dockerfile to build cr8s-fe-server
 └── docker-compose.yml          # Full-stack container definition
 ```
 

--- a/docs/dev-container-usage.md
+++ b/docs/dev-container-usage.md
@@ -65,8 +65,8 @@ CI workflow can use:
 
 To speed up builds and avoid permission errors:
 
-- `/app/target` → `${CR8S_SCRATCH_DIR:-/tmp/tmp}/dev-target`
-- `/usr/local/cargo/registry` → `${CR8S_SCRATCH_DIR:-/tmp/tmp}/dev-cargo`
+- `/app/target` → `${CR8S_SCRATCH_DIR:-/var/tmp}/dev-target`
+- `/usr/local/cargo/registry` → `${CR8S_SCRATCH_DIR:-/var/tmp}/dev-cargo`
 
 These volumes are reused across container runs and cleaned up via:
 
@@ -77,7 +77,7 @@ docker compose down -v
 sudo rm -rf "$CR8S_SCRATCH_DIR/dev-target" "$CR8S_SCRATCH_DIR/dev-cargo"
 ```
 
-✅ As of **v0.3.0**, both `quickstart` and `docker-compose.yml` now default to the same scratch path fallback: `/tmp/tmp`. When `CR8S_SCRATCH_DIR` is set, all tooling — including Compose volume mounts — will respect this value for consistent cross-environment behavior.
+✅ As of **v0.3.0**, both `quickstart` and `docker-compose.yml` now default to the same scratch path fallback: `/var/tmp`. When `CR8S_SCRATCH_DIR` is set, all tooling — including Compose volume mounts — will respect this value for consistent cross-environment behavior.
 
 
 ## Frontend Compilation and Playwright

--- a/docs/manual-e2e-tests.md
+++ b/docs/manual-e2e-tests.md
@@ -16,7 +16,7 @@ Ensure services are running first. Choose your preferred startup mode:
 💡 **Note:** If you're running `quickstart` via the container-based workflow, the CLI binary is built inside the dev container under:
 
 ```bash
-${CR8S_SCRATCH_DIR:-/tmp/tmp}/dev-target/debug/quickstart
+${CR8S_SCRATCH_DIR:-/var/tmp}/dev-target/debug/quickstart
 ```
 
 This is a temporary path and will be deleted when you run:


### PR DESCRIPTION
docs: update scratch volume path default to /var/tmp

- Change CR8S_SCRATCH_DIR fallback from /tmp/tmp → /var/tmp across all docs
- Update manual-e2e-tests.md and dev-container-usage.md with new mount path
- Adjust project structure diagram in README to reflect removal of legacy scripts/
  and inclusion of cli/, Dockerfile.fe-server, and index.html at root
