### PR TITLE
Preparation for release v0.3.2  Docs/update rust prerequisites v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dual-license metadata (MIT OR Apache-2.0) added to manifest and README
 - LICENSE-MIT and LICENSE-APACHE files included in repo
 
+### Changed
+- Updated README prerequisites to require Rust 1.88.0 or newer alongside Docker
+- Removed note about no local Rust installation being required
+
 ## [v0.3.1] – 2025-06-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cr8s-fe"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Yew/WebAssembly frontend for cr8s. Supports crate release workflows, session auth, and cross-platform CI automation"

--- a/Dockerlogin.md
+++ b/Dockerlogin.md
@@ -1,0 +1,21 @@
+## Docker login with a PAT
+
+1. **Create a GitHub PAT with `read:packages` scope:**
+
+   * Go to [https://github.com/settings/tokens](https://github.com/settings/tokens)
+   * Click **Generate new token (classic)**
+   * (You may be asked to authenticate using your password, a 2FA code, or passkey)
+   * Give the token a descriptive name (e.g., `Docker GHCR access`)
+   * Set expiration as you prefer
+   * Check the box for `read:packages` (minimum for pulling packages)
+   * (Optional) Check `repo` if you also want repository access
+   * Generate and **copy the token immediately** — you won’t see it again
+
+2. **Log in to GHCR with Docker:**
+
+```bash
+docker logout ghcr.io  # clear any existing credentials
+docker login ghcr.io
+# When prompted:
+# Username: your GitHub username (e.g., JohnBasrai)
+# Password: paste your PAT token (not your GitHub password)

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,6 @@
-LICENSE-APACHE
+This project is dual-licensed under either:
+
+- MIT license (see LICENSE-MIT or https://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 (see LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0)
+
+at your option.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Built with ⚡ hot‑reload via Trunk, stateful components, and a clean Tailwind
 
 ## Quick Start  
 
+Before running the container, ensure you are authenticated with GitHub Container Registry.  
+See [Docker Login with PAT](Dockerlogin.md) for instructions on creating a GitHub Personal Access Token (PAT) and logging in to `ghcr.io`.
+
 > ```bash
 > cargo build -p quickstart
 > target/debug/quickstart start --lint basic

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Built with ⚡ hot‑reload via Trunk, stateful components, and a clean Tailwind
 
 ## Prerequisites
 
-* **Docker ≥ 24** & Docker Compose v2
+* **Docker ≥ 24** & Docker Compose v2, Rust 1.88.0 or newer
 
-> **No local Rust installation required!** Everything runs in containers with the pre-built development image.
 > **Note**: The development environment automatically handles user permissions across different systems (local dev, CI, contributors) using containerized tooling.
 
 ---


### PR DESCRIPTION
## Release v0.3.2

- Bump version to 0.3.2 in Cargo.toml
- Update README prerequisites to require Rust 1.88.0+
- Add dual-license metadata (MIT OR Apache-2.0)
- Remove note about no local Rust installation needed

Fixes the v0.3.2 changelog entry that was never properly released.